### PR TITLE
feat: Create documentation and prepare crate for packaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bitflags = "2.0"
 core_affinity = { version = "0.8", optional = true }
 crossbeam = { version = "0.8", optional = true }
 libc = "0.2"
-netmap-min-sys = { version = "0.1.0", optional = true } # Assuming netmap-min-sys is published as 0.1.0
+netmap-min-sys = { path ='netmap-min-sys', optional = true }
 reed-solomon-erasure = { version = "6.0.0", optional = true}
 thiserror = "1.0"
 


### PR DESCRIPTION
- Created a `docs` folder to store documentation.
- Moved `README.md` to `docs/README.md` and updated `Cargo.toml` accordingly.
- Generated HTML documentation for `netmap-rs` using `cargo doc` and placed it in `docs/netmap_rs`.
- Enhanced `src/lib.rs` with a comprehensive `# Usage` section, including a basic code example, and improved other doc comments.
- Ensured `netmap-min-sys/Cargo.toml` has necessary fields for publishing and corrected an author email format.
- Updated `netmap-rs/Cargo.toml` to correct an author email format.
- Modified `netmap-rs/Cargo.toml` to use a path dependency for `netmap-min-sys` to allow local packaging (will need to be changed to version dependency for actual publishing).